### PR TITLE
City func ph1 tests

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,28 +3,25 @@
 # Set the language for all reviews.
 system_language: "en-US"
 
-# A little fun is good, but let's keep the PR comments focused on the review.
+# Keep PR comments focused on the code review.
 disable_poem: true
 
-# It's good practice to ignore draft PRs until they are ready for review.
+# Ignore draft PRs until ready for review.
 ignore_draft_pr: true
 
-# Ignore PRs with "WIP" (Work In Progress) in the title.
+# Ignore PRs with "WIP" in the title.
 ignored_titles: "WIP"
 
 # --------------------------------------------------------------------------
 # --- Path Filtering: Focus the review on what matters most in this course ---
 # --------------------------------------------------------------------------
 path_filters:
-  # Explicitly include all Python files for review.
-  - "**/*.py"
-  # Exclude common files and folders that don't need a code review.
+  - "**/*.py"            # Include all Python files.
   - "!**/__pycache__/**" # Ignore Python's cache directories.
   - "!**/venv/**"        # Ignore virtual environment folders.
   - "!**/.venv/**"
-  - "!**/*.pyc"         # Ignore compiled Python files.
-  - "!**/*.sqlite3"     # Ignore the Django database file.
-  # Exclude assignment documents and assets.
+  - "!**/*.pyc"          # Ignore compiled Python files.
+  - "!**/*.sqlite3"      # Ignore the Django database file.
   - "!**/*.pdf"
   - "!**/*.docx"
   - "!**/*.md"
@@ -36,7 +33,7 @@ path_filters:
 # --------------------------------------------------------------------------
 # --- Custom Instructions: Your AI Mentor's Cheat Sheet 🐍 ---
 # --------------------------------------------------------------------------
-[cite_start]file_path_instructions: # [cite: 1]
+file_path_instructions:
   - path: "**/*.py"
     instructions: |
       Please act as a Python programming mentor for the CSD325 course.
@@ -66,7 +63,6 @@ path_filters:
       - Check that any opened CSV files are properly closed, preferably using a `with` statement.
       - Ensure that all plots generated with Matplotlib have a title, an x-axis label, and a y-axis label for clarity.
       - Verify that different data series (e.g., highs vs. lows) are plotted in different colors to be easily distinguishable.
-    
-# You can disable this status message by setting the reviews.review_status to false in the CodeRabbit configuration file.
+
 reviews:
   review_status: false

--- a/module_7/city_functions.py
+++ b/module_7/city_functions.py
@@ -5,12 +5,22 @@ Assignment: Module 7.2 Test Cases
 Purpose: Provides the city_country function that will be used in the test cases.
 """
 
+import random
 from module_7.constants import CITY_COUNTRIES
+
+
+# Phase 1: Create a function that returns a city and a country.
 
 
 def city_country_str(city: str, country: str) -> str:
     """
     Displays a string in the format City, Country.
+
+    This function takes a city and a country as input and returns a string in the format
+    City, Country.
+
+    The function uses the title() method to capitalize the first letter of each word in
+    the city and country names.
 
     Parameters:
         - city: The name of the city.
@@ -27,7 +37,6 @@ def city_country_str(city: str, country: str) -> str:
 
 
 if __name__ == "__main__":
-    for city_country in CITY_COUNTRIES:
-        print(
-            city_country_str(city=city_country["city"], country=city_country["country"])
-        )
+    num_samples = 1
+    city_and_country = random.choices(CITY_COUNTRIES, weights=None, k=num_samples)
+    print(city_country_str(city_and_country[0]["city"], city_and_country[0]["country"]))

--- a/module_7/constants.py
+++ b/module_7/constants.py
@@ -1,30 +1,19 @@
 """
 Constant values for the application.
 
-This module is used to store constants for the application. Since the assignment requires
-multiple iterations of the same code, these values are stored in a separate module so
-there isn't a concern if all the code is changed or modified.
+This module is used to store constants for the application. Since the assignment
+requires multiple iterations of the same code, these values are stored in a separate
+module so there isn't a concern if all the code is changed or modified.
 """
 
 CITY_COUNTRIES = [
-    {
-        "city": "Santiago",
-        "country": "Chile"
-    },
-    {
-        "city": "Sao Paulo",
-        "country": "Brazil"
-    },
-    {
-        "city": "Tokyo",
-        "country": "Japan"
-    },
-    {
-        "city": "New York",
-        "country": "United States"
-    },
-    {
-        "city": "Paris",
-        "country": "France"
-    },
+    {"city": "Santiago", "country": "Chile"},
+    {"city": "Sao Paulo", "country": "Brazil"},
+    {"city": "Tokyo", "country": "Japan"},
+    {"city": "New York", "country": "United States"},
+    {"city": "Paris", "country": "France"},
+    {"city": "London", "country": "United Kingdom"},
+    {"city": "Rome", "country": "Italy"},
+    {"city": "Moscow", "country": "Russia"},
+    {"city": "Beijing", "country": "China"},
 ]


### PR DESCRIPTION
## Summary by Sourcery

Update the constants module with additional cities and inline formatting, refine function documentation, and modify main execution to output a randomly chosen city-country pair.

New Features:
- Print a randomly selected city-country pair in the main script using random.choices

Enhancements:
- Expand CITY_COUNTRIES to include London, Rome, Moscow, and Beijing
- Refactor constant entries into inline dictionaries
- Enhance city_country_str docstring to document title-casing behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new city-country pairs: London (United Kingdom), Rome (Italy), Moscow (Russia), and Beijing (China).

* **Changes**
  * When running the script, a single random city-country pair is now displayed instead of listing all pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->